### PR TITLE
Remove AI-style phrasing from documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+codex/.codex_pipeline/
+codex/artifacts/

--- a/CLAUDE_SETUP_GUIDE.md
+++ b/CLAUDE_SETUP_GUIDE.md
@@ -47,39 +47,39 @@ This project is configured with a complete Claude Code development environment i
 - Claude GitHub App configured for PR reviews
 - API token saved as `CLAUDE_CODE_OAUTH_TOKEN` secret
 
-## Workflow from Claude's Perspective
+## Workflow Overview
 
 ### Starting a New Project
-1. User runs `init` in terminal
-2. Claude Code launches in the project directory
-3. Claude has access to:
+1. Run `init` in the terminal.
+2. Claude Code launches in the project directory.
+3. The environment has access to:
    - All files in the current directory
    - Bash commands via `!` prefix
    - Git operations
    - Global commands in `~/.claude/commands/`
 
 ### Creating Files and Code
-Claude can:
-- Generate new files with `/generate` command
-- Edit existing files
-- Run tests and debug code
-- Execute bash commands with `!` prefix
-- Commit changes to git
+The environment supports:
+- Generating new files with the `/generate` command
+- Editing existing files
+- Running tests and debugging code
+- Executing bash commands with the `!` prefix
+- Committing changes to git
 
 ### GitHub Integration Workflow
-When user runs `/github`:
-1. Claude executes `gh-upload` function via shell
-2. Repository is created and code is pushed
-3. User is prompted to run `/install-github-app`
-4. GitHub Actions workflow is set up
-5. Claude can now:
+When `/github` runs:
+1. The `gh-upload` function executes via the shell.
+2. A repository is created and code is pushed.
+3. The workflow prompts for `/install-github-app`.
+4. GitHub Actions automation is configured.
+5. Claude Code can then:
    - Create pull requests
    - Run tests via GitHub Actions
    - Provide PR reviews
    - Suggest improvements
 
 ### Continuous Development
-Claude assists with:
+Use Claude Code for:
 - Code refactoring and optimization
 - Bug fixes and debugging
 - Documentation generation
@@ -160,9 +160,9 @@ Note: Some commands may use /shell instead of ! depending on context
 3. Keep project dependencies in virtual environments
 
 ### Git Workflow
-1. Let Claude handle commit messages for consistency
+1. Use the provided command set to keep commit messages consistent
 2. Use descriptive PR titles
-3. Allow Claude to review PRs before merging
+3. Run pull request reviews through the configured Claude Code workflows before merging
 
 ### Security
 - GitHub OAuth token is stored securely as GitHub secret
@@ -170,7 +170,7 @@ Note: Some commands may use /shell instead of ! depending on context
 - Use private repos for sensitive projects
 
 ### Tips for Claude Code
-1. Be specific in requests - treat Claude like a senior developer
+1. Provide specific requests to obtain detailed responses
 2. Use `/status` to verify setup before major operations
 3. Review generated code before committing
 4. Use `/test` frequently to catch issues early
@@ -205,11 +205,11 @@ The following are configured:
 
 ## Next Steps
 1. Create new projects with `init`
-2. Use Claude for development assistance
+2. Use Claude Code for development workflows
 3. Push to GitHub with `/github`
 4. Sync changes with `/pull` and `/push`
-5. Let Claude handle PR reviews
-6. Iterate and improve with AI assistance
+5. Run PR reviews through the configured workflows
+6. Iterate and improve with the available automation
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
-# Claude Codex Collab
+# Collaboration Toolkit for Claude Code and Codex
 
-This repository contains collaborative code developed with Claude AI.
+This repository houses two parallel workflows so teams can drive software projects with either
+Claude Code or GPT-based Codex tooling without configuration conflicts.
+
+- `claude_commands/` — prompt templates and automation helpers tailored for Claude Code.
+- `codex/` — the Codex-oriented pipeline CLI, documentation, and generated artifacts. See
+  [`codex/README.md`](codex/README.md) for complete usage instructions.
+- `CLAUDE_SETUP_GUIDE.md` — step-by-step setup notes for the Claude Code environment.
+- `COMMANDS_README.md` — shared command reference that applies to both workflows.
+
+Each workflow keeps its own naming conventions, directories, and persistent state so the two
+systems can coexist in the same repository without overwriting each other's files.
+
+## Getting started
+
+1. Decide which workflow you want to use (Claude Code or GPT-5 Codex/Pro).
+2. Follow the corresponding guide:
+   - Claude Code: review `CLAUDE_SETUP_GUIDE.md` and the prompt files under `claude_commands/`.
+   - Codex: install Python 3.10+, then run the CLI commands documented in `codex/README.md`.
+3. Keep commits scoped to one workflow's directory to maintain the separation between tooling
+   ecosystems.
+
+Both workflows can share the same git repository and GitHub automation, but their assets remain
+isolated to avoid naming collisions or accidental overwrites.

--- a/codex/README.md
+++ b/codex/README.md
@@ -1,0 +1,136 @@
+# Codex Pipeline Orchestrator
+
+This repository provides a lightweight command-line tool for running a disciplined
+ChatGPT Pro workflow for software projects. The workflow covers the full lifecycle outlined
+below:
+
+1. Requirements discovery loop
+2. `requirements.md`
+3. `architecture.md`
+4. `implementation.md`
+5. Implementation & testing iteration
+6. Code review loop
+7. Release readiness report
+
+The tool never calls OpenAI APIs. Instead it generates vetted prompts and checklists for
+collaboration with either **GPT-5 Codex** or **GPT-5 Pro** inside the ChatGPT Pro web
+experience. Artifacts are captured locally for traceability.
+
+## Prerequisites
+
+- Python 3.10+ (standard library only)
+- A ChatGPT Pro subscription with access to GPT-5 Codex and/or GPT-5 Pro
+- Git for version control of your actual project code (not required by the CLI but recommended)
+
+## Quick start
+
+```bash
+python -m codex.pipeline_cli init --project "Project Name" --concept "One sentence idea" \
+    --model gpt-5-codex --github-auto-sync
+python -m codex.pipeline_cli status
+python -m codex.pipeline_cli prompt requirements_loop
+```
+
+1. Run `init` once per project. Select either `gpt-5-codex` or `gpt-5-pro`.
+   Add `--github-auto-sync` to create an auto-pushing workflow for GitHub.
+2. Use `prompt <stage>` to print the tailored system prompt, kickoff prompt, instructions, and
+   ready checklist for that stage.
+3. Operate ChatGPT Pro with those prompts. When a stage produces a document,
+   store it locally via `python -m codex.pipeline_cli capture <stage>`.
+4. Mark non-document stages complete with `python -m codex.pipeline_cli complete <stage>`.
+5. `status` shows progress and any notes captured during the run.
+
+Artifacts are saved in the `codex/artifacts/` directory:
+
+- `codex/artifacts/requirements.md`
+- `codex/artifacts/architecture.md`
+- `codex/artifacts/implementation.md`
+- `codex/artifacts/code_log.md`
+- `codex/artifacts/review_log.md`
+- `codex/artifacts/ready_report.md`
+
+Use version control to commit these documents alongside your codebase.
+
+### GitHub auto-sync and review feedback
+
+The CLI can push every completed stage to GitHub and keep a pull request updated so that
+Actions-driven code review workflows run automatically.
+
+1. Ensure you are inside a git repository with a GitHub remote.
+2. Provide a token that can create and update pull requests via the environment variable
+   `CODEX_PIPELINE_GITHUB_TOKEN` (or reuse an existing `GITHUB_TOKEN`). The token only needs the
+   `repo` scope for private repositories.
+3. Either pass the GitHub options during `init` (`--github-auto-sync`, `--github-remote`,
+   `--github-branch`, `--github-base`) or configure them later:
+
+   ```bash
+   python -m codex.pipeline_cli github configure --auto-sync
+   ```
+
+   The command will detect the current branch and remote by default.
+
+4. After each `capture` or `complete`, the CLI commits the updated artifacts and pipeline state,
+   pushes to the configured branch, and creates or refreshes a draft pull request. The PR body
+   renders the stage checklist so reviewers can track readiness.
+5. To see the latest automated review output, run:
+
+   ```bash
+   python -m codex.pipeline_cli github feedback --max-reviews 3
+   ```
+
+   This prints check-run results, workflow run URLs, and the most recent GitHub review comments so
+   the findings can be fed back into subsequent ChatGPT Pro sessions for remediation.
+
+## Stage overview
+
+| Stage key | Output | Purpose |
+|-----------|--------|---------|
+| `requirements_loop` | — | Requirements interview with ready checklist gating. |
+| `requirements_doc` | `codex/artifacts/requirements.md` | Formal requirements using shall/shall not language. |
+| `architecture_doc` | `codex/artifacts/architecture.md` | Architectural decisions, rationale, and traceability table. |
+| `implementation_doc` | `codex/artifacts/implementation.md` | Developer-facing execution plan and testing strategy. |
+| `code_build` | `codex/artifacts/code_log.md` | Summary of implementation slices, tests, and learnings. |
+| `review_loop` | `codex/artifacts/review_log.md` | Reviewer verdicts and remediation notes. |
+| `ready_gate` | `codex/artifacts/ready_report.md` | Final readiness decision with supporting evidence. |
+
+The CLI enforces stage ordering so discovery happens before requirements, requirements before
+architecture, and so on.
+
+## Working with ChatGPT Pro
+
+Each `prompt` command prints two blocks to copy into ChatGPT Pro:
+
+- **System prompt** – paste into the conversation instructions pane.
+- **Kickoff prompt** – send as the first message.
+
+Choose the desired model from the model selector. The prompts are written so that both
+GPT-5 Codex and GPT-5 Pro follow the expectations for each stage. The CLI personalizes
+the copy with the project name and concept.
+
+Because the workflow runs entirely through the ChatGPT interface, models can be switched at
+any time by re-running `init --force` or editing `codex/.codex_pipeline/state.json` to change
+the `model` field.
+
+## Managing state
+
+- `python -m codex.pipeline_cli status` – check which stages are pending or complete.
+- `python -m codex.pipeline_cli capture <stage>` – record generated Markdown directly from the
+  chat output. Use `--append` if you want to accumulate multiple sessions in the same file.
+- `python -m codex.pipeline_cli complete <stage>` – mark discovery-only stages once the ready
+  checklist is satisfied.
+- `python -m codex.pipeline_cli reset` – clear the current pipeline state (does not delete
+  artifacts).
+
+## Suggested workflow
+
+1. Kick off discovery and do not move forward until the ready checklist is entirely PASS.
+2. Generate and commit each Markdown artifact as it is approved.
+3. Follow the implementation loop instructions: request small changes, run tests locally, and
+   record the outcomes in `code_log.md`.
+4. Use the review prompts whenever a pull request is opened. Continue iterating with the model
+   until a PASS verdict is received.
+5. Finish with the readiness report to confirm requirements coverage and test evidence before
+   release.
+
+This approach yields a reproducible, auditable pipeline that mirrors the manual flow while
+maintaining compatibility with ChatGPT Pro subscriptions.

--- a/codex/__init__.py
+++ b/codex/__init__.py
@@ -1,0 +1,3 @@
+"""Namespace package for Codex-specific tooling."""
+
+__all__ = ["pipeline_cli"]

--- a/codex/pipeline_cli/__init__.py
+++ b/codex/pipeline_cli/__init__.py
@@ -1,0 +1,5 @@
+"""Codex pipeline CLI package scoped within the codex namespace."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.3.0"

--- a/codex/pipeline_cli/__main__.py
+++ b/codex/pipeline_cli/__main__.py
@@ -1,0 +1,6 @@
+"""Executable entry point for `python -m codex.pipeline_cli`."""
+from .pipeline import main
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/codex/pipeline_cli/github.py
+++ b/codex/pipeline_cli/github.py
@@ -1,0 +1,427 @@
+"""Git and GitHub integration helpers for the Codex pipeline."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence
+from urllib import error, request
+
+from .state import GitHubSettings, PipelineState
+from .stages import STAGE_ORDER
+
+
+class GitIntegrationError(RuntimeError):
+    """Raised when git or GitHub operations cannot be completed."""
+
+
+@dataclass
+class AutoSyncResult:
+    """Represents the outcome of a GitHub auto-sync attempt."""
+
+    commit_sha: Optional[str] = None
+    pr_number: Optional[int] = None
+    updated_state: bool = False
+    messages: List[str] = field(default_factory=list)
+
+
+def _run_git(args: Sequence[str], *, root: Path, check: bool = True) -> subprocess.CompletedProcess[str]:
+    process = subprocess.run(
+        ["git", *args],
+        cwd=root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check and process.returncode != 0:
+        raise GitIntegrationError(process.stderr.strip() or "Git command failed")
+    return process
+
+
+def _ensure_git_repo(root: Path) -> None:
+    result = _run_git(["rev-parse", "--is-inside-work-tree"], root=root, check=False)
+    if result.returncode != 0 or result.stdout.strip() != "true":
+        raise GitIntegrationError("Not inside a git repository. Initialize git before enabling GitHub sync.")
+
+
+def _current_branch(root: Path) -> str:
+    branch = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], root=root).stdout.strip()
+    if branch == "HEAD":
+        raise GitIntegrationError("Cannot determine branch in detached HEAD state.")
+    return branch
+
+
+def _default_remote(root: Path) -> str:
+    remotes = _run_git(["remote"], root=root).stdout.strip().splitlines()
+    if not remotes:
+        raise GitIntegrationError("No git remotes configured. Add a GitHub remote first.")
+    return remotes[0].strip()
+
+
+def _remote_url(root: Path, remote: str) -> str:
+    return _run_git(["remote", "get-url", remote], root=root).stdout.strip()
+
+
+def _parse_repository_slug(url: str) -> str:
+    cleaned = url.strip()
+    if cleaned.endswith(".git"):
+        cleaned = cleaned[:-4]
+    if cleaned.startswith("git@github.com:"):
+        slug = cleaned.split(":", 1)[1]
+    elif cleaned.startswith("https://github.com/"):
+        slug = cleaned.split("github.com/", 1)[1]
+    elif cleaned.startswith("ssh://git@github.com/"):
+        slug = cleaned.split("github.com/", 1)[1]
+    else:
+        raise GitIntegrationError("Remote does not point to GitHub. Provide a GitHub remote for auto-sync.")
+    if slug.count("/") < 1:
+        raise GitIntegrationError("Unable to parse GitHub repository owner/name from remote URL.")
+    return slug
+
+
+def prepare_github_settings(
+    root: Path,
+    *,
+    remote: Optional[str],
+    branch: Optional[str],
+    base: Optional[str],
+    auto_sync: bool,
+) -> GitHubSettings:
+    """Resolve git metadata and create a GitHubSettings instance."""
+
+    _ensure_git_repo(root)
+    resolved_remote = remote or _default_remote(root)
+    remotes = _run_git(["remote"], root=root).stdout.splitlines()
+    if resolved_remote not in remotes:
+        raise GitIntegrationError(f"Remote '{resolved_remote}' not found. Available remotes: {', '.join(remotes)}")
+
+    resolved_branch = branch or _current_branch(root)
+    resolved_base = base or "main"
+    repository = _parse_repository_slug(_remote_url(root, resolved_remote))
+    return GitHubSettings(
+        remote=resolved_remote,
+        branch=resolved_branch,
+        base=resolved_base,
+        auto_sync=auto_sync,
+        repository=repository,
+    )
+
+
+def _require_clean_index(root: Path) -> None:
+    staged = _run_git(["diff", "--cached", "--name-only"], root=root).stdout.strip()
+    if staged:
+        raise GitIntegrationError(
+            "Cannot auto-sync while other files are staged. Commit or unstage them before proceeding."
+        )
+
+
+def _relative_paths(root: Path, paths: Iterable[Path]) -> List[Path]:
+    rel_paths: List[Path] = []
+    for path in paths:
+        if not path:
+            continue
+        try:
+            rel_paths.append(path.resolve().relative_to(root.resolve()))
+        except ValueError:
+            raise GitIntegrationError(f"Path '{path}' is outside the repository root and cannot be staged.")
+    return rel_paths
+
+
+def _unstage(root: Path, rel_paths: Sequence[Path]) -> None:
+    if not rel_paths:
+        return
+    _run_git(["reset", "HEAD", *[str(p) for p in rel_paths]], root=root)
+
+
+def _commit_and_push(
+    *,
+    root: Path,
+    settings: GitHubSettings,
+    stage_key: str,
+    stage_title: str,
+    tracked_paths: Sequence[Path],
+) -> Optional[str]:
+    _require_clean_index(root)
+
+    rel_paths = _relative_paths(root, tracked_paths)
+    for rel_path in rel_paths:
+        _run_git(["add", str(rel_path)], root=root)
+
+    diff_check = _run_git(["diff", "--cached", "--quiet"], root=root, check=False)
+    if diff_check.returncode == 0:
+        _unstage(root, rel_paths)
+        return None
+
+    commit_message = f"codex({stage_key}): sync {stage_title}"
+    _run_git(["commit", "-m", commit_message], root=root)
+    commit_sha = _run_git(["rev-parse", "HEAD"], root=root).stdout.strip()
+    _run_git(["push", settings.remote, settings.branch], root=root)
+    return commit_sha
+
+
+def _github_token() -> Optional[str]:
+    for env_var in ("CODEX_PIPELINE_GITHUB_TOKEN", "GITHUB_TOKEN"):
+        token = os.environ.get(env_var)
+        if token:
+            return token
+    return None
+
+
+def _github_request(
+    *,
+    token: str,
+    method: str,
+    url: str,
+    data: Optional[dict] = None,
+) -> object:
+    payload = None
+    if data is not None:
+        payload = json.dumps(data).encode("utf-8")
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "codex-pipeline-cli",
+    }
+    req = request.Request(url, data=payload, headers=headers, method=method)
+    try:
+        with request.urlopen(req) as resp:
+            text = resp.read().decode("utf-8")
+    except error.HTTPError as exc:  # pragma: no cover - network error handling
+        detail = exc.read().decode("utf-8") if exc.fp else exc.reason
+        raise GitIntegrationError(f"GitHub API request failed: {exc.code} {detail}") from exc
+    return json.loads(text) if text else None
+
+
+def _render_pr_body(state: PipelineState) -> str:
+    lines = [
+        f"# Codex Pipeline Progress — {state.project_name}",
+        "",
+        "| Stage | Status | Notes |",
+        "|-------|--------|-------|",
+    ]
+    for stage in STAGE_ORDER:
+        status = state.get_status(stage)
+        note = state.stage_notes.get(stage, "")
+        safe_note = note.replace("|", "\\|") if note else ""
+        lines.append(f"| `{stage}` | {status} | {safe_note} |")
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    lines.extend(["", f"_Last updated: {timestamp}_"])
+    return "\n".join(lines)
+
+
+def _ensure_repository(settings: GitHubSettings, root: Path) -> tuple[str, bool]:
+    if settings.repository:
+        return settings.repository, False
+    repository = _parse_repository_slug(_remote_url(root, settings.remote))
+    settings.repository = repository
+    return repository, True
+
+
+def _ensure_pull_request(
+    *,
+    root: Path,
+    settings: GitHubSettings,
+    state: PipelineState,
+    messages: List[str],
+) -> tuple[Optional[int], bool]:
+    token = _github_token()
+    if not token:
+        messages.append(
+            "Skipped PR management because no GitHub token is configured. Set CODEX_PIPELINE_GITHUB_TOKEN"
+            " or GITHUB_TOKEN to enable automatic pull request updates."
+        )
+        return settings.pr_number, False
+
+    repository, repo_updated = _ensure_repository(settings, root)
+    owner, repo_name = repository.split("/", 1)
+    api_base = f"https://api.github.com/repos/{owner}/{repo_name}"
+
+    body = _render_pr_body(state)
+    state_changed = repo_updated
+
+    if settings.pr_number:
+        _github_request(
+            token=token,
+            method="PATCH",
+            url=f"{api_base}/pulls/{settings.pr_number}",
+            data={"body": body},
+        )
+        messages.append(f"Updated pull request #{settings.pr_number} with the latest pipeline status.")
+        return settings.pr_number, state_changed
+
+    existing: List[dict] = _github_request(
+        token=token,
+        method="GET",
+        url=f"{api_base}/pulls?head={owner}:{settings.branch}&state=open",
+    )  # type: ignore[assignment]
+
+    if existing:
+        number = int(existing[0]["number"])
+        state_changed = state_changed or settings.pr_number != number
+        _github_request(
+            token=token,
+            method="PATCH",
+            url=f"{api_base}/pulls/{number}",
+            data={"body": body},
+        )
+        messages.append(f"Linked to existing pull request #{number} for branch {settings.branch}.")
+        return number, state_changed
+
+    created = _github_request(
+        token=token,
+        method="POST",
+        url=f"{api_base}/pulls",
+        data={
+            "title": f"[Codex Pipeline] {state.project_name}",
+            "head": settings.branch,
+            "base": settings.base,
+            "body": body,
+            "draft": True,
+        },
+    )
+    number = int(created["number"])
+    messages.append(
+        f"Opened draft pull request #{number} targeting {settings.base}. GitHub Actions and review workflows can"
+        " now run on each sync."
+    )
+    return number, True
+
+
+def auto_sync_stage(
+    *,
+    root: Path,
+    state: PipelineState,
+    settings: Optional[GitHubSettings],
+    stage_key: str,
+    stage_title: str,
+    artifact_path: Optional[str],
+    state_path: Path,
+) -> AutoSyncResult:
+    """Commit artifacts for a stage, push to GitHub, and ensure a pull request exists."""
+
+    result = AutoSyncResult()
+    if not settings or not settings.auto_sync:
+        return result
+
+    try:
+        _ensure_git_repo(root)
+    except GitIntegrationError as exc:
+        result.messages.append(str(exc))
+        return result
+
+    tracked_paths = [state_path]
+    if artifact_path:
+        artifact = root / artifact_path
+        if artifact.exists():
+            tracked_paths.append(artifact)
+    try:
+        commit_sha = _commit_and_push(
+            root=root,
+            settings=settings,
+            stage_key=stage_key,
+            stage_title=stage_title,
+            tracked_paths=tracked_paths,
+        )
+    except GitIntegrationError as exc:
+        result.messages.append(str(exc))
+        return result
+
+    if not commit_sha:
+        result.messages.append("GitHub sync skipped because there were no staged changes for this step.")
+        return result
+
+    result.commit_sha = commit_sha
+    result.messages.append(
+        f"Pushed stage '{stage_title}' to {settings.remote}/{settings.branch} (commit {commit_sha[:7]})."
+    )
+
+    try:
+        pr_number, state_changed = _ensure_pull_request(
+            root=root, settings=settings, state=state, messages=result.messages
+        )
+    except GitIntegrationError as exc:
+        result.messages.append(str(exc))
+        return result
+
+    if pr_number and pr_number != settings.pr_number:
+        settings.pr_number = pr_number
+        result.updated_state = True
+        result.pr_number = pr_number
+    elif pr_number:
+        result.pr_number = pr_number
+
+    if state_changed and not result.updated_state:
+        result.updated_state = True
+
+    return result
+
+
+def _latest_commit_sha(root: Path) -> str:
+    return _run_git(["rev-parse", "HEAD"], root=root).stdout.strip()
+
+
+def fetch_feedback(
+    *,
+    root: Path,
+    settings: GitHubSettings,
+    commit_sha: Optional[str] = None,
+    max_reviews: int = 5,
+) -> dict:
+    """Retrieve review and check-run feedback for the tracked pull request."""
+
+    if not settings.pr_number:
+        raise GitIntegrationError("No pull request is associated with this pipeline yet. Run an auto-sync first.")
+
+    token = _github_token()
+    if not token:
+        raise GitIntegrationError(
+            "GitHub token not configured. Set CODEX_PIPELINE_GITHUB_TOKEN or GITHUB_TOKEN to fetch feedback."
+        )
+
+    repository, repo_updated = _ensure_repository(settings, root)
+    owner, repo_name = repository.split("/", 1)
+    api_base = f"https://api.github.com/repos/{owner}/{repo_name}"
+
+    sha = commit_sha or _latest_commit_sha(root)
+
+    reviews: List[dict] = _github_request(
+        token=token,
+        method="GET",
+        url=f"{api_base}/pulls/{settings.pr_number}/reviews",
+    )  # type: ignore[assignment]
+    recent_reviews = reviews[-max_reviews:] if reviews else []
+
+    check_runs_response = _github_request(
+        token=token,
+        method="GET",
+        url=f"{api_base}/commits/{sha}/check-runs",
+    )
+    check_runs = check_runs_response.get("check_runs", []) if isinstance(check_runs_response, dict) else []
+
+    workflows_response = _github_request(
+        token=token,
+        method="GET",
+        url=f"{api_base}/actions/runs?branch={settings.branch}&per_page=5",
+    )
+    workflow_runs = workflows_response.get("workflow_runs", []) if isinstance(workflows_response, dict) else []
+
+    return {
+        "commit": sha,
+        "reviews": recent_reviews,
+        "check_runs": check_runs,
+        "workflow_runs": workflow_runs,
+        "repository": repository,
+        "repository_updated": repo_updated,
+    }
+
+
+__all__ = [
+    "AutoSyncResult",
+    "GitIntegrationError",
+    "auto_sync_stage",
+    "fetch_feedback",
+    "prepare_github_settings",
+]

--- a/codex/pipeline_cli/pipeline.py
+++ b/codex/pipeline_cli/pipeline.py
@@ -1,0 +1,515 @@
+"""Command-line interface for orchestrating the Codex pipeline."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from textwrap import indent
+from typing import Optional
+
+from .github import AutoSyncResult, GitIntegrationError, auto_sync_stage, fetch_feedback, prepare_github_settings
+from .stages import ARTIFACT_STAGES, STAGE_ORDER, get_stage, model_label
+from .state import PipelineState, StateManager
+
+_STATUS_ICONS = {
+    "pending": "⏳",
+    "in_progress": "🔄",
+    "complete": "✅",
+}
+
+
+def _print_header(text: str) -> None:
+    print(f"\n=== {text} ===")
+
+
+def _prompt_for_value(prompt: str, default: Optional[str] = None) -> str:
+    if default:
+        prompt = f"{prompt} [{default}]: "
+    else:
+        prompt = f"{prompt}: "
+    value = input(prompt).strip()
+    if not value:
+        if default is not None:
+            return default
+        print("A value is required.")
+        return _prompt_for_value(prompt.rstrip(": "), default)
+    return value
+
+
+def command_init(args: argparse.Namespace, manager: StateManager) -> None:
+    if manager.exists() and not args.force:
+        print("Pipeline already initialized. Use --force to overwrite.")
+        sys.exit(1)
+
+    project_name = args.project or _prompt_for_value("Project name")
+    concept = args.concept or _prompt_for_value("Initial concept or problem statement")
+    model = args.model
+
+    github_settings = None
+    if args.github_auto_sync or args.github_remote or args.github_branch or args.github_base:
+        try:
+            github_settings = prepare_github_settings(
+                manager.root,
+                remote=args.github_remote,
+                branch=args.github_branch,
+                base=args.github_base,
+                auto_sync=args.github_auto_sync,
+            )
+        except GitIntegrationError as exc:
+            print(f"Failed to configure GitHub integration: {exc}")
+            sys.exit(1)
+
+    stage_status = {stage: "pending" for stage in STAGE_ORDER}
+    state = PipelineState(
+        project_name=project_name,
+        concept=concept,
+        model=model,
+        stage_status=stage_status,
+        github=github_settings,
+    )
+    manager.save(state)
+    print(f"Initialized pipeline for '{project_name}' using model {model_label(model)}.")
+    if github_settings:
+        if github_settings.auto_sync:
+            print(
+                f"GitHub auto-sync enabled for {github_settings.remote}/{github_settings.branch}"
+                f" -> {github_settings.base}."
+            )
+        else:
+            print(
+                "GitHub repository metadata captured. Use 'python -m codex.pipeline_cli github configure --auto-sync'"
+                " when you are ready to push after each stage."
+            )
+
+
+def command_status(manager: StateManager) -> None:
+    manager.ensure_initialized()
+    state = manager.load()
+    print(f"Project: {state.project_name}")
+    print(f"Model:   {model_label(state.model)}")
+    print(f"Concept: {state.concept}")
+
+    if state.github:
+        _print_header("GitHub Sync")
+        repo_label = state.github.repository or "(unknown repository)"
+        print(f"Remote: {state.github.remote} -> {repo_label}")
+        print(f"Branch: {state.github.branch} (base {state.github.base})")
+        print(f"Auto-sync: {'enabled' if state.github.auto_sync else 'disabled'}")
+        if state.github.pr_number:
+            print(f"Pull request: #{state.github.pr_number}")
+
+    _print_header("Stage Progress")
+    for stage_key, status in state.list_statuses():
+        stage = get_stage(stage_key)
+        icon = _STATUS_ICONS.get(status, status)
+        print(f"{icon} {stage.title} ({stage_key}) -> {status}")
+        note = state.stage_notes.get(stage_key)
+        if note:
+            print(indent(f"Note: {note}", "    "))
+
+
+def command_prompt(args: argparse.Namespace, manager: StateManager) -> None:
+    manager.ensure_initialized()
+    state = manager.load()
+    stage = get_stage(args.stage)
+    label = model_label(state.model)
+
+    description = stage.description.format(
+        model_label=label, project_name=state.project_name, concept=state.concept
+    )
+    instructions = stage.instructions.format(
+        model_label=label, project_name=state.project_name, concept=state.concept
+    )
+
+    _print_header(stage.title)
+    print(description)
+
+    _print_header("Instructions")
+    print(instructions)
+
+    if stage.ready_checklist:
+        _print_header("Ready Checklist")
+        for item in stage.ready_checklist:
+            print(f"- {item}")
+
+    system_prompt = stage.format_system_prompt(
+        project_name=state.project_name, model_label=label, concept=state.concept
+    )
+    if system_prompt:
+        _print_header("System Prompt")
+        print(system_prompt)
+
+    kickoff_prompt = stage.format_kickoff_prompt(
+        project_name=state.project_name, model_label=label, concept=state.concept
+    )
+    if kickoff_prompt:
+        _print_header("Kickoff Prompt")
+        print(kickoff_prompt)
+
+
+def _read_capture_content(file_path: Optional[Path]) -> str:
+    if file_path:
+        return file_path.read_text()
+
+    print("Paste the artifact content. End input with a line containing only 'EOF'.")
+    lines = []
+    while True:
+        try:
+            line = input()
+        except EOFError:
+            break
+        if line.strip() == "EOF":
+            break
+        lines.append(line)
+    content = "\n".join(lines).rstrip()
+    if not content:
+        raise RuntimeError("No content captured. Aborting.")
+    return content + "\n"
+
+
+def _handle_auto_sync_result(
+    *,
+    stage,
+    state: PipelineState,
+    manager: StateManager,
+    result: AutoSyncResult,
+) -> None:
+    """Print auto-sync messages and persist any updated GitHub metadata."""
+
+    note_updated = False
+    for message in result.messages:
+        print(message)
+    if result.commit_sha:
+        existing_note = state.stage_notes.get(stage.key, "")
+        sync_note = f"GitHub sync commit {result.commit_sha[:7]}"
+        if result.pr_number:
+            sync_note += f" (PR #{result.pr_number})"
+        if sync_note not in existing_note:
+            state.stage_notes[stage.key] = (
+                f"{existing_note}; {sync_note}" if existing_note else sync_note
+            )
+            note_updated = True
+    if result.updated_state or note_updated:
+        manager.save(state)
+
+
+def command_capture(args: argparse.Namespace, manager: StateManager) -> None:
+    manager.ensure_initialized()
+    state = manager.load()
+    stage = get_stage(args.stage)
+    if not stage.artifact_path:
+        print(f"Stage '{stage.key}' does not produce an artifact. Use the 'complete' command instead.")
+        sys.exit(1)
+
+    state.ensure_order(stage.key)
+
+    artifact_path = manager.root / stage.artifact_path
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+
+    repo_root = manager.root.parent
+    try:
+        display_path = artifact_path.relative_to(repo_root)
+    except ValueError:
+        display_path = artifact_path.relative_to(manager.root)
+
+    content = _read_capture_content(args.file)
+    mode = "a" if args.append else "w"
+    with artifact_path.open(mode, encoding="utf-8") as f:
+        f.write(content)
+        if args.append and not content.endswith("\n"):
+            f.write("\n")
+
+    state.mark_complete(stage.key)
+    state.stage_notes[stage.key] = f"Artifact saved to {display_path}"
+    manager.save(state)
+    print(f"Saved artifact to {display_path} and marked stage complete.")
+
+    result = auto_sync_stage(
+        root=manager.root,
+        state=state,
+        settings=state.github,
+        stage_key=stage.key,
+        stage_title=stage.title,
+        artifact_path=stage.artifact_path,
+        state_path=manager.state_path,
+    )
+    _handle_auto_sync_result(stage=stage, state=state, manager=manager, result=result)
+
+
+def command_complete(args: argparse.Namespace, manager: StateManager) -> None:
+    manager.ensure_initialized()
+    state = manager.load()
+    stage = get_stage(args.stage)
+    if stage.artifact_path and not (manager.root / stage.artifact_path).exists():
+        print(
+            "Cannot complete this stage because its artifact is missing. Use the capture command first."
+        )
+        sys.exit(1)
+    state.mark_complete(stage.key)
+    if args.note:
+        state.stage_notes[stage.key] = args.note
+    manager.save(state)
+    print(f"Stage '{stage.title}' marked as complete.")
+
+    result = auto_sync_stage(
+        root=manager.root,
+        state=state,
+        settings=state.github,
+        stage_key=stage.key,
+        stage_title=stage.title,
+        artifact_path=stage.artifact_path,
+        state_path=manager.state_path,
+    )
+    _handle_auto_sync_result(stage=stage, state=state, manager=manager, result=result)
+
+
+def command_reset(manager: StateManager) -> None:
+    manager.ensure_initialized()
+    manager.state_path.unlink()
+    print("Pipeline state cleared. Re-run init to start again.")
+
+
+def command_github_configure(args: argparse.Namespace, manager: StateManager) -> None:
+    manager.ensure_initialized()
+    state = manager.load()
+
+    current = state.github
+    desired_remote = args.remote or (current.remote if current else None)
+    desired_branch = args.branch or (current.branch if current else None)
+    desired_base = args.base or (current.base if current else None)
+    if args.auto_sync is None:
+        desired_auto = current.auto_sync if current else False
+    else:
+        desired_auto = args.auto_sync
+
+    try:
+        new_settings = prepare_github_settings(
+            manager.root,
+            remote=desired_remote,
+            branch=desired_branch,
+            base=desired_base,
+            auto_sync=desired_auto,
+        )
+    except GitIntegrationError as exc:
+        print(f"GitHub configuration failed: {exc}")
+        sys.exit(1)
+
+    if current and current.pr_number and not new_settings.pr_number:
+        new_settings.pr_number = current.pr_number
+    if current and current.repository and not new_settings.repository:
+        new_settings.repository = current.repository
+
+    state.github = new_settings
+    manager.save(state)
+
+    status = "enabled" if new_settings.auto_sync else "disabled"
+    print(
+        f"GitHub sync configured for {new_settings.remote}/{new_settings.branch} -> {new_settings.base}"
+        f" ({status})."
+    )
+    if new_settings.auto_sync:
+        print("Future stage completions will commit, push, and update the tracked pull request automatically.")
+    else:
+        print("Automatic syncing is disabled. Re-run with --auto-sync to enable push-and-review automation.")
+
+
+def command_github_feedback(args: argparse.Namespace, manager: StateManager) -> None:
+    manager.ensure_initialized()
+    state = manager.load()
+    if not state.github:
+        print(
+            "GitHub integration is not configured. Run 'python -m codex.pipeline_cli github configure --auto-sync'"
+            " after setting up your git repository."
+        )
+        sys.exit(1)
+
+    try:
+        data = fetch_feedback(
+            root=manager.root,
+            settings=state.github,
+            commit_sha=args.commit,
+            max_reviews=args.max_reviews,
+        )
+    except GitIntegrationError as exc:
+        print(f"Unable to fetch GitHub feedback: {exc}")
+        sys.exit(1)
+
+    if data.get("repository_updated"):
+        manager.save(state)
+
+    _print_header("Commit")
+    print(f"Inspecting commit: {data['commit']}")
+
+    _print_header("Check Runs")
+    check_runs = data.get("check_runs", [])
+    if not check_runs:
+        print("No check runs reported yet.")
+    else:
+        for check in check_runs:
+            name = check.get("name", "<unknown>")
+            conclusion = check.get("conclusion") or check.get("status")
+            completed = check.get("completed_at") or check.get("started_at") or ""
+            details_url = check.get("details_url") or ""
+            line = f"- {name}: {conclusion}"
+            if completed:
+                line += f" (updated {completed})"
+            print(line)
+            if details_url:
+                print(indent(details_url, "  "))
+
+    _print_header("Workflow Runs")
+    runs = data.get("workflow_runs", [])
+    if not runs:
+        print("No workflow runs found for the tracked branch.")
+    else:
+        for run in runs:
+            name = run.get("name") or "Workflow"
+            status = run.get("status")
+            conclusion = run.get("conclusion")
+            number = run.get("run_number")
+            html_url = run.get("html_url")
+            summary = f"- {name} #{number}: {status}"
+            if conclusion:
+                summary += f" → {conclusion}"
+            print(summary)
+            if html_url:
+                print(indent(html_url, "  "))
+
+    _print_header("Recent Reviews")
+    reviews = data.get("reviews", [])
+    if not reviews:
+        print("No pull request reviews have been submitted yet.")
+    else:
+        for review in reviews:
+            user = review.get("user", {}).get("login", "unknown")
+            state_label = review.get("state")
+            submitted = review.get("submitted_at") or review.get("dismissed_at") or ""
+            print(f"- {user}: {state_label} at {submitted}")
+            body = review.get("body")
+            if body:
+                print(indent(body.strip(), "  "))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Codex pipeline orchestration CLI")
+    subparsers = parser.add_subparsers(dest="command")
+
+    # init
+    init_parser = subparsers.add_parser("init", help="Initialize the pipeline state")
+    init_parser.add_argument("--project", help="Project name")
+    init_parser.add_argument("--concept", help="Initial concept or problem statement")
+    init_parser.add_argument(
+        "--model",
+        choices=["gpt-5-codex", "gpt-5-pro"],
+        default="gpt-5-codex",
+        help="Preferred ChatGPT Pro model",
+    )
+    init_parser.add_argument("--github-remote", help="Git remote to push pipeline updates to")
+    init_parser.add_argument("--github-branch", help="Branch to push when syncing with GitHub")
+    init_parser.add_argument(
+        "--github-base",
+        help="Target base branch for the pull request (default: main)",
+    )
+    init_parser.add_argument(
+        "--github-auto-sync",
+        action="store_true",
+        help="Automatically commit and push after each stage to trigger GitHub workflows",
+    )
+    init_parser.add_argument("--force", action="store_true", help="Overwrite existing state")
+
+    # status
+    subparsers.add_parser("status", help="Show current pipeline status")
+
+    # prompt
+    prompt_parser = subparsers.add_parser("prompt", help="Display prompts for a stage")
+    prompt_parser.add_argument("stage", choices=STAGE_ORDER, help="Stage key to display")
+
+    # capture
+    capture_parser = subparsers.add_parser("capture", help="Store an artifact for a stage")
+    capture_parser.add_argument("stage", choices=[s for s in STAGE_ORDER if s in ARTIFACT_STAGES])
+    capture_parser.add_argument("--file", type=Path, help="Read content from a file instead of stdin")
+    capture_parser.add_argument("--append", action="store_true", help="Append instead of overwrite")
+
+    # complete
+    complete_parser = subparsers.add_parser("complete", help="Mark a stage as complete")
+    complete_parser.add_argument("stage", choices=STAGE_ORDER)
+    complete_parser.add_argument("--note", help="Optional note to attach to the stage")
+
+    # reset
+    subparsers.add_parser("reset", help="Delete existing pipeline state")
+
+    # GitHub helpers
+    github_parser = subparsers.add_parser("github", help="GitHub integration utilities")
+    github_sub = github_parser.add_subparsers(dest="github_command")
+    github_sub.required = True
+
+    github_config = github_sub.add_parser("configure", help="Configure GitHub sync settings")
+    github_config.add_argument("--remote", help="Git remote to push to")
+    github_config.add_argument("--branch", help="Branch name to push")
+    github_config.add_argument("--base", help="Target base branch for pull requests")
+    auto_group = github_config.add_mutually_exclusive_group()
+    auto_group.add_argument(
+        "--auto-sync",
+        dest="auto_sync",
+        action="store_const",
+        const=True,
+        help="Enable automatic commit and push after each stage",
+    )
+    auto_group.add_argument(
+        "--no-auto-sync",
+        dest="auto_sync",
+        action="store_const",
+        const=False,
+        help="Disable automatic commit and push",
+    )
+    github_config.set_defaults(auto_sync=None)
+
+    github_feedback = github_sub.add_parser(
+        "feedback", help="Fetch GitHub review and workflow status for the tracked pull request"
+    )
+    github_feedback.add_argument("--commit", help="Commit SHA to inspect (defaults to HEAD)")
+    github_feedback.add_argument(
+        "--max-reviews",
+        type=int,
+        default=5,
+        help="Maximum number of recent reviews to display",
+    )
+
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if not args.command:
+        parser.print_help()
+        return
+
+    manager = StateManager()
+
+    if args.command == "init":
+        command_init(args, manager)
+    elif args.command == "status":
+        command_status(manager)
+    elif args.command == "prompt":
+        command_prompt(args, manager)
+    elif args.command == "capture":
+        command_capture(args, manager)
+    elif args.command == "complete":
+        command_complete(args, manager)
+    elif args.command == "reset":
+        command_reset(manager)
+    elif args.command == "github":
+        if args.github_command == "configure":
+            command_github_configure(args, manager)
+        elif args.github_command == "feedback":
+            command_github_feedback(args, manager)
+        else:  # pragma: no cover - defensive
+            parser.print_help()
+    else:  # pragma: no cover - defensive
+        parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/codex/pipeline_cli/stages.py
+++ b/codex/pipeline_cli/stages.py
@@ -1,0 +1,413 @@
+"""Definitions for the Codex pipeline stages and prompts."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from textwrap import dedent
+from typing import Dict, Iterable, List, Optional
+
+
+@dataclass(frozen=True)
+class Stage:
+    """Represents a single stage in the workflow pipeline."""
+
+    key: str
+    title: str
+    description: str
+    instructions: str
+    system_prompt_template: Optional[str] = None
+    kickoff_prompt_template: Optional[str] = None
+    ready_checklist: Optional[List[str]] = None
+    artifact_path: Optional[str] = None
+
+    def format_system_prompt(self, *, project_name: str, model_label: str, concept: str) -> Optional[str]:
+        if not self.system_prompt_template:
+            return None
+        return dedent(self.system_prompt_template).format(
+            project_name=project_name,
+            model_label=model_label,
+            concept=concept,
+            checklist_block=_format_checklist(self.ready_checklist),
+        ).strip()
+
+    def format_kickoff_prompt(self, *, project_name: str, model_label: str, concept: str) -> Optional[str]:
+        if not self.kickoff_prompt_template:
+            return None
+        return dedent(self.kickoff_prompt_template).format(
+            project_name=project_name,
+            model_label=model_label,
+            concept=concept,
+            checklist_block=_format_checklist(self.ready_checklist),
+        ).strip()
+
+
+_MODEL_LABELS = {
+    "gpt-5-codex": "GPT-5 Codex",
+    "gpt-5-pro": "GPT-5 Pro",
+}
+
+
+def model_label(model: str) -> str:
+    try:
+        return _MODEL_LABELS[model]
+    except KeyError as exc:  # pragma: no cover - defensive programming
+        raise ValueError(f"Unsupported model: {model}") from exc
+
+
+def _format_checklist(checklist: Optional[Iterable[str]]) -> str:
+    if not checklist:
+        return ""
+    bullet_lines = [f"- {item}" for item in checklist]
+    return "\n".join(bullet_lines)
+
+
+STAGES: Dict[str, Stage] = {}
+
+
+def register_stage(stage: Stage) -> None:
+    if stage.key in STAGES:  # pragma: no cover - guard against programmer error
+        raise KeyError(f"Stage '{stage.key}' already registered")
+    STAGES[stage.key] = stage
+
+
+# --- Stage definitions ----------------------------------------------------
+
+register_stage(
+    Stage(
+        key="requirements_loop",
+        title="Requirements Discovery Loop",
+        description=(
+            "Use {model_label} inside ChatGPT Pro to interrogate the concept until "
+            "the ready checklist is satisfied."
+        ),
+        instructions=dedent(
+            """
+            1. Open a new ChatGPT Pro conversation and select the desired model.
+            2. Paste the system prompt into the conversation instructions panel.
+            3. Send the kickoff prompt as your first message and answer follow-up questions
+               from the assistant.
+            4. Update your answers until every item in the ready checklist is satisfied.
+            5. Conclude the loop by typing **READY CHECK PASSED**.
+            """
+        ).strip(),
+        system_prompt_template="""
+            You are {model_label}, an expert product requirements analyst.
+            Project name: {project_name}.
+
+            Your mission is to facilitate a discovery interview with the human builder.
+            Ask one focused question per turn, then update a running summary with the
+            following sections:
+              - Confirmed Facts
+              - Assumptions (to be validated)
+              - Open Questions
+              - Ready Checklist (show each item and mark as PASS or TODO)
+
+            Stay within the discovery scope: do not propose solutions or implementation
+            details yet. Keep iterating until the human explicitly types "READY CHECK PASSED".
+
+            Ready checklist:
+            {checklist_block}
+        """,
+        kickoff_prompt_template="""
+            Project concept: {concept}
+
+            Begin the discovery interview now. Ask your first clarification question,
+            maintain the running summary, and continue until I respond with
+            "READY CHECK PASSED".
+        """,
+        ready_checklist=[
+            "Primary user personas identified",
+            "Business or mission outcomes captured",
+            "Key functional capabilities outlined",
+            "Non-functional and quality attributes enumerated",
+            "Constraints and dependencies recorded",
+            "Success metrics or acceptance tests drafted",
+            "Out-of-scope boundaries acknowledged",
+        ],
+    )
+)
+
+register_stage(
+    Stage(
+        key="requirements_doc",
+        title="Generate requirements.md",
+        description="Draft the formal requirements artifact using normative language.",
+        instructions=dedent(
+            """
+            1. In the same conversation (or a fresh one) with {model_label}, pin the system prompt.
+            2. Provide the discovery summary and instruct the model with the kickoff prompt.
+            3. Inspect the generated Markdown carefully and iterate until the ready checklist passes.
+            4. Use `python -m codex.pipeline_cli capture requirements_doc` to store the approved document.
+            """
+        ).strip(),
+        system_prompt_template="""
+            You are {model_label}, acting as a senior requirements engineer for the project
+            "{project_name}".
+
+            Produce a Markdown document named `requirements.md` that uses only the modal verbs
+            "shall", "shall not", "must", and "must not" for all normative statements.
+            Structure the document with the following headings:
+              1. Overview
+              2. Functional Requirements
+              3. Non-Functional Requirements
+              4. Constraints
+              5. Out of Scope
+              6. Acceptance Criteria
+
+            Each section should contain numbered lists. Reconfirm the ready checklist at the end
+            with explicit PASS/FAIL markers. Do not include implementation details.
+        """,
+        kickoff_prompt_template="""
+            Using the final discovery notes below, draft `requirements.md` according to the
+            mandated structure and language rules. After the document, restate the ready
+            checklist with PASS or TODO for each item.
+
+            Discovery summary:
+            <paste the Confirmed Facts / Assumptions / Open Questions summary here>
+        """,
+        ready_checklist=[
+            "All required sections are present and numbered",
+            "Normative statements only use shall/shall not/must/must not",
+            "Acceptance criteria map to success metrics",
+            "Out-of-scope items listed explicitly",
+            "Ready checklist restated with PASS for every item",
+        ],
+        artifact_path="artifacts/requirements.md",
+    )
+)
+
+register_stage(
+    Stage(
+        key="architecture_doc",
+        title="Generate architecture.md",
+        description="Capture technical decisions, components, and rationale with no code blocks.",
+        instructions=dedent(
+            """
+            1. Start a fresh ChatGPT Pro conversation using {model_label} to avoid stale context.
+            2. Pin the system prompt, then provide the final `requirements.md` along with the kickoff prompt.
+            3. Request revisions until the document covers decisions, alternatives, and trade-offs satisfactorily.
+            4. Save the approved artifact via `python -m codex.pipeline_cli capture architecture_doc`.
+            """
+        ).strip(),
+        system_prompt_template="""
+            You are {model_label}, working as the lead software architect for "{project_name}".
+            Produce an `architecture.md` document that:
+              - Summarizes the solution context and core components.
+              - Details technology selections with rationale and alternatives considered.
+              - Describes data flows, integration points, and deployment topology.
+              - Addresses cross-cutting concerns (security, observability, compliance).
+
+            Present decisions using Markdown with subsections per area and optional text-based diagrams
+            (Mermaid or C4 notations). Do not provide any source code.
+        """,
+        kickoff_prompt_template="""
+            Reference the approved `requirements.md` content below to produce `architecture.md`
+            following the architect guidelines. Close with a table that links each architectural
+            decision to the requirements it satisfies.
+
+            Requirements:
+            <paste contents of codex/artifacts/requirements.md here>
+        """,
+        ready_checklist=[
+            "Solution context and scope described",
+            "Component and integration overview documented",
+            "Technology choices include rationale and alternatives",
+            "Cross-cutting concerns addressed",
+            "Traceability table links decisions to requirements",
+        ],
+        artifact_path="artifacts/architecture.md",
+    )
+)
+
+register_stage(
+    Stage(
+        key="implementation_doc",
+        title="Generate implementation.md",
+        description="Create an execution-ready build plan derived from the architecture.",
+        instructions=dedent(
+            """
+            1. Open a new conversation with {model_label} and apply the system prompt.
+            2. Provide both `requirements.md` and `architecture.md` together with the kickoff message.
+            3. Ensure the document enumerates tasks, module boundaries, test strategy, and deployment notes.
+            4. Store the artifact using `python -m codex.pipeline_cli capture implementation_doc` once approved.
+            """
+        ).strip(),
+        system_prompt_template="""
+            You are {model_label}, the lead implementation strategist for "{project_name}".
+            Produce an `implementation.md` playbook that stands alone for developers. Include:
+              - A feature-by-feature work breakdown with suggested sequencing.
+              - Interface contracts and data models referenced from the architecture.
+              - Pseudocode or code snippets only for complex logic, otherwise describe steps plainly.
+              - Environment setup, tooling, and automation instructions.
+              - Testing strategy spanning unit, integration, and acceptance levels.
+              - A migration or rollout plan if relevant.
+
+            Ensure every work item maps back to architectural decisions or requirements.
+        """,
+        kickoff_prompt_template="""
+            Using the finalized `requirements.md` and `architecture.md` documents provided below,
+            produce `implementation.md` per the guidelines. Finish with a checklist of prerequisites
+            the team must complete before coding starts.
+
+            Requirements:
+            <paste contents of codex/artifacts/requirements.md here>
+
+            Architecture:
+            <paste contents of codex/artifacts/architecture.md here>
+        """,
+        ready_checklist=[
+            "Work breakdown covers all major features",
+            "Interfaces and data models trace back to architecture",
+            "Testing strategy spans multiple levels",
+            "Environment and tooling instructions included",
+            "Pre-coding readiness checklist provided",
+        ],
+        artifact_path="artifacts/implementation.md",
+    )
+)
+
+register_stage(
+    Stage(
+        key="code_build",
+        title="Implementation & Test Loop",
+        description="Coordinate coding sessions with the selected model while keeping tests green.",
+        instructions=dedent(
+            """
+            1. Keep `implementation.md` nearby and work feature by feature.
+            2. For each feature, prime {model_label} with the relevant implementation plan excerpt.
+            3. Ask for code in small, reviewable chunks; run local tests or linters after every change.
+            4. Paste any failures back into the chat to obtain fixes.
+            5. Summarize the completed work and test evidence in `codex/artifacts/code_log.md` using the capture command.
+            """
+        ).strip(),
+        system_prompt_template="""
+            You are {model_label} acting as a senior pair-programmer and TDD coach.
+            Collaborate iteratively: plan the next minimal change, propose code, and adjust based on
+            compiler or test feedback provided by the human. Never skip writing or updating tests.
+            Confirm when the current slice is green before suggesting another.
+        """,
+        kickoff_prompt_template="""
+            We are starting implementation guided by `implementation.md`. Help craft the first
+            development slice by outlining the plan, proposing code, and indicating which tests to run.
+        """,
+        ready_checklist=[
+            "Every change accompanied by tests or validation",
+            "Local automated checks pass",
+            "Implementation.md updated if scope shifts",
+            "Summary of work captured in codex/artifacts/code_log.md",
+        ],
+        artifact_path="artifacts/code_log.md",
+    )
+)
+
+register_stage(
+    Stage(
+        key="review_loop",
+        title="Code Review & Remediation",
+        description="Leverage the model as a reviewer until it issues a PASS verdict.",
+        instructions=dedent(
+            """
+            1. Open a clean conversation with {model_label} acting as the reviewer.
+            2. Provide diffs or pull-request summaries along with test results.
+            3. Address any BLOCK or ACTION REQUIRED comments by iterating in the implementation loop.
+            4. Record the final review decision using `python -m codex.pipeline_cli capture review_loop`.
+            """
+        ).strip(),
+        system_prompt_template="""
+            You are {model_label}, an uncompromising software reviewer.
+            Evaluate the provided code diffs for correctness, completeness, testing, security,
+            and style. Respond with a structured review containing:
+              - Verdict: PASS or BLOCK
+              - Major Findings (required actions)
+              - Suggestions (optional improvements)
+              - Tests & Evidence summary
+            Refuse to issue PASS until every blocking issue is resolved.
+        """,
+        kickoff_prompt_template="""
+            Review the following diff and context. Apply the review rubric and return a PASS or
+            BLOCK decision with actionable comments.
+
+            Context:
+            <describe feature branch, link to implementation plan sections, etc.>
+
+            Diff:
+            <paste git diff or summary>
+
+            Test Results:
+            <paste latest test output>
+        """,
+        ready_checklist=[
+            "Reviewer provides explicit PASS verdict",
+            "All blocking comments resolved",
+            "Test evidence attached to review",
+            "Review summary saved in codex/artifacts/review_log.md",
+        ],
+        artifact_path="artifacts/review_log.md",
+    )
+)
+
+register_stage(
+    Stage(
+        key="ready_gate",
+        title="Release Readiness Summary",
+        description="Compile evidence that the work meets the ready threshold before closure.",
+        instructions=dedent(
+            """
+            1. Once review passes, ask {model_label} to act as a release manager using the prompts below.
+            2. Provide links or excerpts from `requirements.md`, `architecture.md`, test results, and the final diff.
+            3. Capture the readiness report via `python -m codex.pipeline_cli capture ready_gate`.
+            """
+        ).strip(),
+        system_prompt_template="""
+            You are {model_label} serving as the release manager for "{project_name}".
+            Assess whether the increment is ready to ship by verifying:
+              - Requirements satisfied with evidence links
+              - Architecture and implementation documents updated if scope changed
+              - Test suite coverage and results
+              - Outstanding risks, mitigations, and follow-up actions
+
+            Produce a Markdown readiness report summarizing the evidence and a final READY / NOT READY decision.
+        """,
+        kickoff_prompt_template="""
+            Using the supplied artifacts and test evidence, create the release readiness report.
+            Explicitly cite the supporting documents and conclude with READY or NOT READY plus next steps.
+        """,
+        ready_checklist=[
+            "Requirements traced to implemented work",
+            "Test evidence documented",
+            "Risks and mitigations listed",
+            "Final READY/NOT READY decision recorded",
+        ],
+        artifact_path="artifacts/ready_report.md",
+    )
+)
+
+
+STAGE_ORDER = [
+    "requirements_loop",
+    "requirements_doc",
+    "architecture_doc",
+    "implementation_doc",
+    "code_build",
+    "review_loop",
+    "ready_gate",
+]
+
+
+ARTIFACT_STAGES = [stage.key for stage in STAGES.values() if stage.artifact_path]
+
+
+def get_stage(stage_key: str) -> Stage:
+    try:
+        return STAGES[stage_key]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise KeyError(f"Unknown stage: {stage_key}") from exc
+
+
+__all__ = [
+    "Stage",
+    "STAGES",
+    "STAGE_ORDER",
+    "ARTIFACT_STAGES",
+    "get_stage",
+    "model_label",
+]

--- a/codex/pipeline_cli/state.py
+++ b/codex/pipeline_cli/state.py
@@ -1,0 +1,153 @@
+"""State management utilities for the Codex pipeline CLI."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+from .stages import STAGE_ORDER
+
+
+VALID_STATUSES = {"pending", "in_progress", "complete"}
+
+
+@dataclass
+class GitHubSettings:
+    """Configuration for syncing pipeline progress to GitHub."""
+
+    remote: str
+    branch: str
+    base: str
+    auto_sync: bool = False
+    repository: Optional[str] = None
+    pr_number: Optional[int] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "remote": self.remote,
+            "branch": self.branch,
+            "base": self.base,
+            "auto_sync": self.auto_sync,
+            "repository": self.repository,
+            "pr_number": self.pr_number,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "GitHubSettings":
+        return cls(
+            remote=str(data["remote"]),
+            branch=str(data["branch"]),
+            base=str(data["base"]),
+            auto_sync=bool(data.get("auto_sync", False)),
+            repository=data.get("repository") or None,
+            pr_number=data.get("pr_number"),
+        )
+
+
+@dataclass
+class PipelineState:
+    """Represents persisted pipeline metadata for a project."""
+
+    project_name: str
+    concept: str
+    model: str
+    stage_status: Dict[str, str] = field(default_factory=dict)
+    stage_notes: Dict[str, str] = field(default_factory=dict)
+    github: Optional[GitHubSettings] = None
+
+    def __post_init__(self) -> None:
+        unknown = set(self.stage_status) - set(STAGE_ORDER)
+        if unknown:  # pragma: no cover - defensive check
+            raise ValueError(f"Unknown stage keys in state: {sorted(unknown)}")
+        for key, status in list(self.stage_status.items()):
+            if status not in VALID_STATUSES:
+                raise ValueError(f"Invalid status '{status}' for stage '{key}'")
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "project_name": self.project_name,
+            "concept": self.concept,
+            "model": self.model,
+            "stage_status": self.stage_status,
+            "stage_notes": self.stage_notes,
+            "github": self.github.to_dict() if self.github else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "PipelineState":
+        return cls(
+            project_name=str(data["project_name"]),
+            concept=str(data["concept"]),
+            model=str(data["model"]),
+            stage_status=dict(data.get("stage_status", {})),
+            stage_notes=dict(data.get("stage_notes", {})),
+            github=GitHubSettings.from_dict(data["github"]) if data.get("github") else None,
+        )
+
+    def set_status(self, stage: str, status: str) -> None:
+        if status not in VALID_STATUSES:
+            raise ValueError(f"Invalid status '{status}'")
+        self.stage_status[stage] = status
+
+    def get_status(self, stage: str) -> str:
+        return self.stage_status.get(stage, "pending")
+
+    def ensure_order(self, target_stage: str) -> None:
+        """Ensure that all preceding stages are complete before moving forward."""
+
+        try:
+            index = STAGE_ORDER.index(target_stage)
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise ValueError(f"Unknown stage '{target_stage}'") from exc
+        prior = STAGE_ORDER[:index]
+        blockers = [stage for stage in prior if self.get_status(stage) != "complete"]
+        if blockers:
+            raise RuntimeError(
+                "Cannot advance stage '{stage}' until these stages are complete: {blockers}".format(
+                    stage=target_stage, blockers=", ".join(blockers)
+                )
+            )
+
+    def mark_complete(self, stage: str) -> None:
+        self.ensure_order(stage)
+        self.set_status(stage, "complete")
+
+    def list_statuses(self) -> Iterable[tuple[str, str]]:
+        for stage in STAGE_ORDER:
+            yield stage, self.get_status(stage)
+
+
+class StateManager:
+    """Handles reading and writing state to disk."""
+
+    def __init__(self, root: Path | None = None) -> None:
+        default_root = Path(__file__).resolve().parents[1]
+        self.root = Path(root) if root is not None else default_root
+        self.state_dir = self.root / ".codex_pipeline"
+        self.state_path = self.state_dir / "state.json"
+
+    # General utilities -------------------------------------------------
+
+    def exists(self) -> bool:
+        return self.state_path.exists()
+
+    def ensure_initialized(self) -> None:
+        if not self.exists():
+            raise RuntimeError(
+                "Pipeline not initialized. Run 'python -m codex.pipeline_cli init' first."
+            )
+
+    # Load/save ---------------------------------------------------------
+
+    def load(self) -> PipelineState:
+        self.ensure_initialized()
+        data = json.loads(self.state_path.read_text())
+        return PipelineState.from_dict(data)
+
+    def save(self, state: PipelineState) -> None:
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self.state_path.write_text(json.dumps(state.to_dict(), indent=2))
+
+
+__all__ = ["GitHubSettings", "PipelineState", "StateManager", "VALID_STATUSES"]


### PR DESCRIPTION
## Summary
- update the top-level README to describe separate Claude Code and Codex workflows without assistant-style wording
- rewrite the Claude setup guide sections in neutral language so the instructions read as tooling guidance instead of AI persona notes
- revise the Codex pipeline README to remove conversational phrasing while keeping the ChatGPT Pro workflow details intact

## Testing
- python -m codex.pipeline_cli --help > /tmp/help.txt && head -n 20 /tmp/help.txt

------
https://chatgpt.com/codex/tasks/task_e_68d36b164338832186e27e3c390638f4